### PR TITLE
Use addItem for UiLinearlayout and UiRectlayout instead of addChild

### DIFF
--- a/docs/UiElements.md
+++ b/docs/UiElements.md
@@ -258,7 +258,7 @@ fontParams | _object_ | FontParams | lumin.ui.FontParams
     allCaps: boolean
 }
 ```
-
+---
 ## UiScrollBar
 
 ### Tag: `<scrollBar>`

--- a/platform/lumin-runtime/platform-factory.js
+++ b/platform/lumin-runtime/platform-factory.js
@@ -131,6 +131,15 @@ export class PlatformFactory extends NativeFactory {
                     parent.addItem(child);
                 }
             }
+        } else if (parent instanceof ui.UiLinearLayout || parent instanceof ui.UiGridLayout) {
+            const { Padding, ItemAlignment } = child;
+            if (Padding !== undefined) {
+                if (ItemAlignment !== undefined) {
+                    parent.addItem(child, Padding, ItemAlignment);
+                } else {
+                    parent.addItem(child, Padding);
+                }
+            }
         } else if (parent instanceof ui.UiSlider) {
             if (child instanceof TransformNode) {
                 if (child.offset !== undefined) {


### PR DESCRIPTION
In order to properly add nodes to the Linear and Rect layouts the frameworks needs to use addItem instead of addChild