### PR TITLE
add-server-event-support fixes

### DIFF
--- a/platform/lumin-runtime/controllers/mxs-prism-controller.js
+++ b/platform/lumin-runtime/controllers/mxs-prism-controller.js
@@ -44,6 +44,15 @@ export class MxsPrismController extends PrismController {
         ];
     }
 
+    setParent(parent) {
+        const root = this.getRoot();
+        if (root === undefined || root === null) {
+            this._parent = parent;
+        } else {
+            parent.addChild(root);
+        }
+    }
+
     addChild(child) {
         const root = this.getRoot();
         if (root === undefined || root === null) {
@@ -78,6 +87,11 @@ export class MxsPrismController extends PrismController {
 
     onAttachPrism(prism) {
         const root = this.getRoot();
+        
+        if (this._parent !== undefined) {
+            this._parent.addChild(root);
+            this._parent = undefined;
+        }
 
         if (this._initialProperties !== undefined) {
             const builder = new TransformNodeBuilder();

--- a/platform/lumin-runtime/elements/builders/element-builder.js
+++ b/platform/lumin-runtime/elements/builders/element-builder.js
@@ -41,7 +41,7 @@ export class ElementBuilder {
         if (descriptor.IsNativeSetter) {
             if (typeof element[descriptor.SetterName] === 'function') {
                 try {
-                    element[descriptor.SetterName](value);
+                    element[descriptor.SetterName](descriptor.parse(value));
                 } catch (error) {
                     console.log(error);
                     throw new Error(`[Native.${descriptor.SetterName}]: ${error.name} - ${error.message}\n${error.stack}`);

--- a/platform/lumin-runtime/elements/builders/transform-node-builder.js
+++ b/platform/lumin-runtime/elements/builders/transform-node-builder.js
@@ -53,7 +53,8 @@ export class TransformNodeBuilder extends ElementBuilder {
     }
 
     _attachOffsetProperty(element) {
-        return element['offset'] = [0, 0, 0];
+        element['offset'] = [0, 0, 0];
+        return element;
     }
 
     excludeProperties(properties, exclude) {

--- a/platform/lumin-runtime/elements/properties/enum-property.js
+++ b/platform/lumin-runtime/elements/properties/enum-property.js
@@ -15,4 +15,8 @@ export class EnumProperty extends PropertyDescriptor {
         this.throwIfConditionFails(value, message, this._enumType[value] !== undefined);
         return true;
     }
+
+    parse (value) {
+        return this._enumType[value];
+    }
 }

--- a/platform/lumin-runtime/elements/properties/property-descriptor.js
+++ b/platform/lumin-runtime/elements/properties/property-descriptor.js
@@ -90,4 +90,8 @@ export class PropertyDescriptor {
             throw new TypeError(message);
         }
     }
+
+    parse (value) {
+        return value;
+    }
 }

--- a/platform/lumin-runtime/platform-factory.js
+++ b/platform/lumin-runtime/platform-factory.js
@@ -221,7 +221,7 @@ export class PlatformFactory extends NativeFactory {
                     throw new Error('Adding controller to non-controller parent');
                 }
                 parent.addChildController(child);
-                parent.getRoot().addChild(child.getRoot());
+                child.setParent(parent);
             } else {
                 if (this.isController(parent)) {
                     parent.addChild(child);


### PR DESCRIPTION
Fixed issues:
- adding `content` tag no longer crashes the application
- nesting two `scene`s no longer crashes the application
- enum properties no longer crash the application