### PR TITLE
Add function addChildController to MxsPrismContoller

### DIFF
--- a/platform/lumin-runtime/controllers/mxs-prism-controller.js
+++ b/platform/lumin-runtime/controllers/mxs-prism-controller.js
@@ -44,15 +44,6 @@ export class MxsPrismController extends PrismController {
         ];
     }
 
-    setParent(parent) {
-        const root = this.getRoot();
-        if (root === undefined || root === null) {
-            this._parent = parent;
-        } else {
-            parent.addChild(root);
-        }
-    }
-
     addChild(child) {
         const root = this.getRoot();
         if (root === undefined || root === null) {
@@ -60,6 +51,11 @@ export class MxsPrismController extends PrismController {
         } else {
             root.addChild(child);
         }
+    }
+
+    addChildController(controller) {
+        super.addChildController(controller);
+        this.addChild(controller.getRoot());
     }
 
     addListener(eventName, eventHandler) {
@@ -87,11 +83,6 @@ export class MxsPrismController extends PrismController {
 
     onAttachPrism(prism) {
         const root = this.getRoot();
-        
-        if (this._parent !== undefined) {
-            this._parent.addChild(root);
-            this._parent = undefined;
-        }
 
         if (this._initialProperties !== undefined) {
             const builder = new TransformNodeBuilder();

--- a/platform/lumin-runtime/elements/builders/element-builder.js
+++ b/platform/lumin-runtime/elements/builders/element-builder.js
@@ -32,7 +32,6 @@ export class ElementBuilder {
                 action(properties[name], descriptor);
             } else {
                 console.log(`Property ${name} does not have a descriptor`);
-                // console.log(`Property ${name} is not recognized as property of ${element.getName()}`);
             }
         }
     }
@@ -43,7 +42,6 @@ export class ElementBuilder {
                 try {
                     element[descriptor.SetterName](descriptor.parse(value));
                 } catch (error) {
-                    console.log(error);
                     throw new Error(`[Native.${descriptor.SetterName}]: ${error.name} - ${error.message}\n${error.stack}`);
                 }
             } else {
@@ -53,7 +51,6 @@ export class ElementBuilder {
             try {
                 this[descriptor.SetterName](element, oldProperties, newProperties);
             } catch (error) {
-                console.log(error);
                 throw new Error(`[Builder.${descriptor.SetterName}]: ${error.name} - ${error.message}\n${error.stack}`);
             }
         }

--- a/platform/lumin-runtime/elements/builders/scroll-view-builder.js
+++ b/platform/lumin-runtime/elements/builders/scroll-view-builder.js
@@ -4,10 +4,12 @@ import { ui, math } from 'lumin';
 
 import { UiNodeBuilder } from './ui-node-builder.js';
 import { ArrayProperty } from '../properties/array-property.js';
+import { ClassProperty } from '../properties/class-property.js';
 import { EnumProperty } from '../properties/enum-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
 
 import { ScrollBarVisibility } from '../../types/scroll-bar-visibility.js';
+import { ScrollDirection } from '../../types/scroll-direction.js';
 
 export class ScrollViewBuilder extends UiNodeBuilder {
     constructor(){

--- a/platform/lumin-runtime/elements/builders/transform-node-builder.js
+++ b/platform/lumin-runtime/elements/builders/transform-node-builder.js
@@ -49,11 +49,10 @@ export class TransformNodeBuilder extends ElementBuilder {
 
         this.apply(element, undefined, unapplied);
 
-        return this._attachOffsetProperty(element);
-    }
+        // Attach 'offset' property
+        // the property is used when TransformNode is used by another node as content/model
+        element.offset = [0, 0, 0];
 
-    _attachOffsetProperty(element) {
-        element['offset'] = [0, 0, 0];
         return element;
     }
 
@@ -65,6 +64,13 @@ export class TransformNodeBuilder extends ElementBuilder {
             }
         });
         return subset;
+    }
+
+    setOffset(element, oldProperties, newProperties) {
+        const offset = newProperties.offset;
+        if (offset !== undefined) {
+            element.offset = offset;
+        }
     }
 
     throwIfInvalidPrism(prism) {

--- a/platform/lumin-runtime/elements/properties/enum-property.js
+++ b/platform/lumin-runtime/elements/properties/enum-property.js
@@ -10,13 +10,13 @@ export class EnumProperty extends PropertyDescriptor {
         this._enumName = enumName;
     }
 
+    parse (value) {
+        return this._enumType[value];
+    }
+
     validate(value) {
         const message = `The provided value ${value} is not valid ${this._enumName} value`;
         this.throwIfConditionFails(value, message, this._enumType[value] !== undefined);
         return true;
-    }
-
-    parse (value) {
-        return this._enumType[value];
     }
 }

--- a/platform/lumin-runtime/elements/properties/property-descriptor.js
+++ b/platform/lumin-runtime/elements/properties/property-descriptor.js
@@ -1,4 +1,5 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
+// import { vec2, vec3, vec4, quat, mat4 } from 'gl-matrix';
 
 const ArrayLengthByType = {
     'vec2': 2,
@@ -33,6 +34,10 @@ export class PropertyDescriptor {
         return this._isNativeSetter;
     }
 
+    parse (value) {
+        return value;
+    }
+
     validate(value) {
         throw new Error('PropertyDescriptor.validate should be overridden');
     }
@@ -60,12 +65,27 @@ export class PropertyDescriptor {
     }
 
     static throwIfNotArray(value, arrayType) {
+        const typedArrayNames = [
+            Int8Array.name,
+            Uint8Array.name,
+            Uint8ClampedArray.name,
+            Int16Array.name,
+            Uint16Array.name,
+            Int32Array.name,
+            Uint32Array.name,
+            Float32Array.name,
+            Float64Array.name
+        ];
+
         if ( this.hasValue(value) ) {
-            if ( !Array.isArray(value) ) {
-                throw new TypeError(`Parameter ${value} should have value of type an array`);
+            if (   !Array.isArray(value)
+                && !typedArrayNames.some(name => name === value.constructor.name) ) {
+                throw new TypeError(`Parameter ${value} should have value of type an array or typed array`);
             }
 
-            if (this.hasValue(arrayType) && value.length !== ArrayLengthByType[arrayType]) {
+            if (   this.hasValue(arrayType)
+                && value.length !== ArrayLengthByType[arrayType]
+                && value.length !== 16) {
                 throw new TypeError(`Parameter ${JSON.stringify(value)} should be ${arrayType} value`);
             }
         }
@@ -89,9 +109,5 @@ export class PropertyDescriptor {
         if ( this.hasValue(value) && !predicate(value) ) {
             throw new TypeError(message);
         }
-    }
-
-    parse (value) {
-        return value;
     }
 }

--- a/platform/lumin-runtime/platform-factory.js
+++ b/platform/lumin-runtime/platform-factory.js
@@ -221,7 +221,6 @@ export class PlatformFactory extends NativeFactory {
                     throw new Error('Adding controller to non-controller parent');
                 }
                 parent.addChildController(child);
-                child.setParent(parent);
             } else {
                 if (this.isController(parent)) {
                     parent.addChild(child);


### PR DESCRIPTION
Adding function addChildController() to MxsPrismContoller would properly add the nested controller without the need of introducing "parent" property for MxsPrismContoller. 

Other fixes: 
- support for JavaScript typed arrays from ArrayPropertyDescriptor.
- resolve missing references for ScrollViewBuilder
