### PR TITLE
Clear all listeners before setting new ones when updating a controller

### DIFF
--- a/platform/lumin-runtime/controllers/builders/controller-builder.js
+++ b/platform/lumin-runtime/controllers/builders/controller-builder.js
@@ -71,6 +71,8 @@ export class ControllerBuilder {
     }
 
     _updateEventHandlers(controller, properties) {
+        controller.clearListeners();
+
         this._eventHandlerNames.forEach(name => {
             const handler = properties[name];
 

--- a/platform/lumin-runtime/controllers/mxs-prism-controller.js
+++ b/platform/lumin-runtime/controllers/mxs-prism-controller.js
@@ -80,6 +80,16 @@ export class MxsPrismController extends PrismController {
             throw TypeError(`Event ${eventName} is not supported by the controller`);
         }
     }
+    
+    clearListeners() {
+        this._eventHandlers = {
+            onPreAttachPrism: [],
+            onAttachPrism: [],
+            onDetachPrism: [],
+            onEvent:[],
+            onUpdate: []
+        };
+    }
 
     onPreAttachPrism(prism) {
         this._eventHandlers.onPreAttachPrism.forEach(handler => handler(prism));


### PR DESCRIPTION
Every time a `render` method was called, a new listener was added to the controller. It was causing the controller to call the same update method multiple times.
