### PR TITLE
Fix a crash when the text property is an empty string

### DIFF
--- a/platform/lumin-runtime/elements/builders/text-container-builder.js
+++ b/platform/lumin-runtime/elements/builders/text-container-builder.js
@@ -26,7 +26,11 @@ export class TextContainerBuilder extends UiNodeBuilder {
     setText(element, oldProperties, newProperties) {
         const { children, text } = newProperties;
         const finalText  = text ? text : this._getText(children);
-        element.setText(finalText);
+        if (finalText !== undefined) {
+            element.setText(finalText);
+        } else {
+            element.setText('');
+        }
     }
 
     _getText(children) {


### PR DESCRIPTION
Fix a crash when the text property is an empty string and the children property is undefined (default case when there is no text set)
