### PR TITLE
Fix typo in LoadingSpinerBuilder for size property

### DIFF
--- a/platform/lumin-runtime/elements/builders/loading-spinner-builder.js
+++ b/platform/lumin-runtime/elements/builders/loading-spinner-builder.js
@@ -14,7 +14,7 @@ export class LoadingSpinnerBuilder extends UiNodeBuilder {
     constructor(){
         super();
 
-        this._propertyDescriptors['size']  = new ArrayProperty('color', 'setSize', true, 'vec2');
+        this._propertyDescriptors['size']  = new ArrayProperty('size', 'setSize', true, 'vec2');
         this._propertyDescriptors['value'] = new PrimitiveTypeProperty('value', 'setValue', true, 'number');
     }
 


### PR DESCRIPTION
The size property was reading from `color` attribute instead of `size`.
