### PR TITLE
Fix a few issues with LayoutBuilder and GridLayoutBuilder.

### DIFF
--- a/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -14,7 +14,9 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
     }
 
     create(prism, properties) {
-        this.throwIfInvalidPrism(prism);
+        // TODO(tcuadra): Should LayoutBuilder inherit from UiNodeBuilder?
+        //                Otherwise move prism function up the builder hierarchy
+        // this.throwIfInvalidPrism(prism);
 
         const element = ui.UiGridLayout.Create(prism);
 

--- a/platform/lumin-runtime/elements/builders/layout-builder.js
+++ b/platform/lumin-runtime/elements/builders/layout-builder.js
@@ -9,8 +9,8 @@ export class LayoutBuilder extends ElementBuilder {
         // this.throwIfNotInstanceOf(element, ui.UiButton);
         super.update(element, oldProperties, newProperties);
 
-        this._validateSize(properties);
-        this._setSize(element, properties);
+        this._validateSize(newProperties);
+        this._setSize(element, newProperties);
     }
 
     validate(element, oldProperties, newProperties) {

--- a/platform/lumin-runtime/platform-factory.js
+++ b/platform/lumin-runtime/platform-factory.js
@@ -176,6 +176,8 @@ export class PlatformFactory extends NativeFactory {
                 } else {
                     parent.addItem(child, Padding);
                 }
+            } else {
+                parent.addItem(child);
             }
         } else if (parent instanceof ui.UiSlider) {
             if (child instanceof TransformNode) {
@@ -282,6 +284,17 @@ export class PlatformFactory extends NativeFactory {
         }
     }
 
+    // TODO(tcuadra): Expose listView.removeItem(ListViewItem) overload
+    //                to avoid the need to perform this lookup
+    _getListViewIndex(listView, item) {
+        for (let i = 0; i < listView.getItemCount(); i++) {
+            if (item === listView.getItem(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     removeChildElement(parent, child) {
         if (typeof child === 'string' || typeof child === 'number') {
             parent.setText('');
@@ -293,6 +306,8 @@ export class PlatformFactory extends NativeFactory {
                 parent.removeChildController(child);
             } else if (this.isController(parent)) {
                 parent.getRoot().removeChild(child);
+            } else if (parent instanceof ui.UiListView) {
+                parent.removeItem(this._getListViewIndex(parent, child));
             } else {
                 parent.removeChild(child);
             }


### PR DESCRIPTION
Also, allow children to be added and removed from a ListView.

Removing a child requires the removeItem function to be called rather than
removeChild directly. Because only the index-based overload is currently
exposed to scripting, we must perform a list item index lookup. For improved
efficiency, the removeItem(ListViewItem) overload should also be exposed.
