### PR TITLE
Compare text property with undefined for text and textEdit elements

### DIFF
--- a/platform/lumin-runtime/elements/builders/text-builder.js
+++ b/platform/lumin-runtime/elements/builders/text-builder.js
@@ -54,13 +54,18 @@ export class TextBuilder extends TextContainerBuilder {
         this.throwIfInvalidPrism(prism);
         this.validate(undefined, undefined, properties);
 
-        const { children, text, style, weight } = properties;
+        let { children, text } = properties;
 
-        const finalText  = text ? text : this._getText(children);
+        if (text === undefined) {
+            text = this._getText(children);
+        }
+        
+        const { style, weight } = properties;
+
         const fontStyle  = style  === undefined ? DEFAULT_FONT_STYLE  : FontStyle[style];
         const fontWeight = weight === undefined ? DEFAULT_FONT_WEIGHT : FontWeight[weight];
 
-        const element = ui.UiText.Create(prism, finalText, fontStyle, fontWeight);
+        const element = ui.UiText.Create(prism, text, fontStyle, fontWeight);
 
         this._setFont2dResource(prism, element, properties);
 

--- a/platform/lumin-runtime/elements/builders/text-edit-builder.js
+++ b/platform/lumin-runtime/elements/builders/text-edit-builder.js
@@ -65,12 +65,15 @@ export class TextEditBuilder extends TextContainerBuilder {
 
     create(prism, properties) {
         this.throwIfInvalidPrism(prism);
-
         this.validate(undefined, undefined, properties);
 
-        const { children, width, height } = properties;
+        let { children, text } = properties;
 
-        const text = this.getPropertyValue('text', this._getText(children), properties);
+        if (text === undefined) {
+            text = this._getText(children);
+        }
+
+        const { width, height } = properties;
 
         const element = ui.UiTextEdit.Create(prism, text, width, height);
 


### PR DESCRIPTION
Property `text` needs to be compared with `undefined` instead of being tested for true because empty string is considered false, while empty string is valid value.