### PR TITLE
Update LayoutBuilder to extend UiNodeBuilder

### DIFF
--- a/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -14,9 +14,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
     }
 
     create(prism, properties) {
-        // TODO(tcuadra): Should LayoutBuilder inherit from UiNodeBuilder?
-        //                Otherwise move prism function up the builder hierarchy
-        // this.throwIfInvalidPrism(prism);
+        this.throwIfInvalidPrism(prism);
 
         const element = ui.UiGridLayout.Create(prism);
 

--- a/platform/lumin-runtime/elements/builders/layout-builder.js
+++ b/platform/lumin-runtime/elements/builders/layout-builder.js
@@ -1,9 +1,9 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 
-import { ElementBuilder } from './element-builder.js';
+import { UiNodeBuilder } from './ui-node-builder.js';
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
 
-export class LayoutBuilder extends ElementBuilder {
+export class LayoutBuilder extends UiNodeBuilder {
 
     update(element, oldProperties, newProperties) {
         // this.throwIfNotInstanceOf(element, ui.UiButton);


### PR DESCRIPTION
This fixes several failed calls to throwIfInvalidPrism in subclasses
(the method does not exist if extending ElementBuilder directly).

Thank you for your contribution to MagicScript Project.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests
