### PR TITLE
Update index.js path from magic-script-renderer.js

### DIFF
--- a/src/react-magic-script/magic-script-renderer.js
+++ b/src/react-magic-script/magic-script-renderer.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 
 import Reconciler from 'react-reconciler';
-import mxs from '../index.js';
+import mxs from '../../index.js';
 
 // Flow type definitions ------------------------------------------------------
 //  Type = string;


### PR DESCRIPTION
After moving the framework source into `src` folder, there was a need to adjust reference to `index.js` from `magic-script-renderer.js`.
