### PR TITLE
Add option to create eclipse button 

### DIFF
--- a/platform/lumin-runtime/elements/builders/button-builder.js
+++ b/platform/lumin-runtime/elements/builders/button-builder.js
@@ -8,7 +8,7 @@ import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js'
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
 
 import { EclipseButtonType } from '../../types/eclipse-button-type.js';
-import { SystemIcon } from '../../types/system-icons.js';
+import { SystemIcons } from '../../types/system-icons.js';
 import { Side } from '../../types/side.js';
 import { validator } from '../../utilities/validator.js';
 
@@ -56,18 +56,13 @@ export class ButtonBuilder extends TextContainerBuilder {
         PropertyDescriptor.throwIfNotTypeOf(newProperties.roundness, 'number');
         PropertyDescriptor.throwIfNotTypeOf(newProperties.iconPath, 'string');
 
-        const buttonType = newProperties.type;
-        const message = `The provided button type ${buttonType} is not a valid value`;
-        PropertyDescriptor.throwIfPredicateFails(buttonType, message, validator.validateEclipseButtonType);
+        this._validateEnumerationValue(newProperties.type, 'button type', validator.validateEclipseButtonType);
+        this._validateEnumerationValue(newProperties.iconType, 'icon type', validator.validateSystemIcon);
+        this._validateEnumerationValue(newProperties.labelSide, 'label side', validator.validateSide);
+    }
 
-        const iconType = newProperties.iconType;
-        const message = `The provided icon type ${iconType} is not a valid value`;
-        PropertyDescriptor.throwIfPredicateFails(iconType, message, validator.validateSystemIcon);
-
-        const labelSide = newProperties.labelSide;
-        const message = `The provided label side ${labelSide} is not a valid value`;
-        PropertyDescriptor.throwIfPredicateFails(labelSide, message, validator.validateSide);
-
+    _validateEnumerationValue(value, messageSubject, predicate) {
+        PropertyDescriptor.throwIfPredicateFails(value, `The provided ${messageSubject} ${value} is not a valid value`, predicate);
     }
 
     getText(children, text) {
@@ -80,7 +75,7 @@ export class ButtonBuilder extends TextContainerBuilder {
 
         // 1. EclipseButtonParams(type, iconPath, text, labelSide, height, iconType)
         if (type !== undefined && iconPath !== undefined && text !== undefined && labelSide !== undefined && height !== undefined && iconType !== undefined) {
-            return new ui.EclipseButtonParams(EclipseButtonType[type], iconPath, text, Side[labelSide], height, SystemIcon[iconType]);
+            return new ui.EclipseButtonParams(EclipseButtonType[type], iconPath, text, Side[labelSide], height, SystemIcons[iconType]);
         }
 
         // 2. EclipseButtonParams(type, iconPath, text, labelSide, height)
@@ -105,7 +100,7 @@ export class ButtonBuilder extends TextContainerBuilder {
 
         // 6. EclipseButtonParams(type, iconType, height)
         if (type !== undefined && iconType !== undefined && height !== undefined) {
-            return new ui.EclipseButtonParams(EclipseButtonType[type], SystemIcon[iconType], height);
+            return new ui.EclipseButtonParams(EclipseButtonType[type], SystemIcons[iconType], height);
         }
 
         // 7. EclipseButtonParams(type)

--- a/platform/lumin-runtime/elements/builders/button-builder.js
+++ b/platform/lumin-runtime/elements/builders/button-builder.js
@@ -7,6 +7,9 @@ import { ArrayProperty } from '../properties/array-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
 
+import { EclipseButtonType } from '../../types/eclipse-button-type.js';
+import { validator } from '../../utilities/validator.js';
+
 export class ButtonBuilder extends TextContainerBuilder {
     constructor(){
         super();
@@ -27,13 +30,23 @@ export class ButtonBuilder extends TextContainerBuilder {
             text = this._getText(children);
         }
 
-        const width = this.getPropertyValue('width', 0.0, properties);
         const height = this.getPropertyValue('height', 0.0, properties);
-        const roundness = this.getPropertyValue('roundness', 1.0, properties);
-        const enabled = this.getPropertyValue('enabled', true, properties);
+        const type = properties.type;
 
-        const element = ui.UiButton.Create(prism, text, width, height, roundness);
-        element.setEnabled(enabled);
+        let element;
+        if (type === undefined) {
+            const width = this.getPropertyValue('width', 0.0, properties);
+            const roundness = this.getPropertyValue('roundness', 1.0, properties);
+
+            element = ui.UiButton.Create(prism, text, width, height, roundness);
+
+            // const enabled = this.getPropertyValue('enabled', true, properties);
+            // element.setEnabled(enabled);
+        } else {
+            const eclipseButtonParams = new ui.EclipseButtonParams(EclipseButtonType[type], properties.iconPath, text, height);
+            element = ui.UiButton.CreateEclipseButton(prism, eclipseButtonParams);
+        }
+
         const unapplied = this.excludeProperties(properties, ['children', 'text', 'width', 'height', 'roundness']);
 
         this.apply(element, undefined, unapplied);
@@ -41,17 +54,17 @@ export class ButtonBuilder extends TextContainerBuilder {
         return element;
     }
 
-    // update(element, oldProperties, newProperties) {
-    //     // this.throwIfNotInstanceOf(element, ui.UiButton);
-    //     super.update(element, oldProperties, newProperties);
-    // }
-
     validate(element, oldProperties, newProperties) {
         super.validate(element, oldProperties, newProperties);
 
         PropertyDescriptor.throwIfNotTypeOf(newProperties.width, 'number');
         PropertyDescriptor.throwIfNotTypeOf(newProperties.height, 'number');
         PropertyDescriptor.throwIfNotTypeOf(newProperties.roundness, 'number');
+        PropertyDescriptor.throwIfNotTypeOf(newProperties.iconPath, 'string');
+
+        const buttonType = newProperties.type;
+        const message = `The provided button type ${buttonType} is not a valid value`;
+        PropertyDescriptor.throwIfPredicateFails(buttonType, message, validator.validateEclipseButtonType);
     }
 }
 


### PR DESCRIPTION
There are seven options to create eclipse button based on provided properties:
1. type, iconPath, text, labelSide, height, iconType
2. type, iconPath, text, labelSide, height
3. type, iconPath, text, height
4. type, iconPath, height
5. type, text, height
6. type, iconType, height
7. type

The only one tested is option (6).