### PR TITLE
Add RayCastEventType and RayCastEventData

### DIFF
--- a/src/platform/lumin-runtime/controllers/mxs-prism-controller.js
+++ b/src/platform/lumin-runtime/controllers/mxs-prism-controller.js
@@ -11,6 +11,7 @@ import { GestureInputEventData } from '../types/event-data/gesture-input-event-d
 import { InputEventData } from '../types/event-data/input-event-data.js';
 import { KeyInputEventData } from '../types/event-data/key-input-event-data.js';
 import { PrismEventData } from '../types/event-data/prism-event-data.js';
+import { RayCastEventData } from '../types/event-data/ray-cast-event-data.js';
 import { SelectionEventData } from '../types/event-data/selection-event-data.js';
 import { UiEventData } from '../types/event-data/ui-event-data.js';
 import { VideoEventData } from '../types/event-data/video-event-data.js';
@@ -40,6 +41,7 @@ export class MxsPrismController extends PrismController {
             GestureInputEventData,
             InputEventData,
             KeyInputEventData,
+            RayCastEventData,
             SelectionEventData,
             UiEventData,
             VideoEventData

--- a/src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js
+++ b/src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
+import { RayCastEventData as _RayCastEventData } from 'lumin';
+import { ServerEvent } from './server-event.js';
+import { RayCastEventType } from '../ray-cast-event-type.js';
+import { extractor } from '../../utilities/extractor.js';
+
+export class RayCastEventData extends ServerEvent {
+
+    get HitData() {
+        const hitData = this._nativeEvent.getHitData();
+        return {
+            distance: hitData.getDistance(),
+            normal: hitData.getNormal(),
+            pointHit: hitData.getPointHit()
+        };
+    }
+
+    get RayCastEvent() {
+        return extractor.getKeyByValue(RayCastEventType, this._nativeEvent.getRayCastEvent());
+    }
+
+    static isSupported(event) {
+        return (event instanceof _VideoEventData);
+    }
+}

--- a/src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js
+++ b/src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js
@@ -20,6 +20,6 @@ export class RayCastEventData extends ServerEvent {
     }
 
     static isSupported(event) {
-        return (event instanceof _VideoEventData);
+        return (event instanceof _RayCastEventData);
     }
 }

--- a/src/platform/lumin-runtime/types/event-data/server-event.js
+++ b/src/platform/lumin-runtime/types/event-data/server-event.js
@@ -19,6 +19,11 @@ export class ServerEvent extends EventData {
         return this._nativeEvent.isInputEventType();
     }
 
+    // Returns a string representation of this event for debug purposes.
+    toString() {
+        return this._nativeEvent.toString();
+    }
+
     static isSupported(event) {
         return (event instanceof _ServerEvent);
     }

--- a/src/platform/lumin-runtime/types/ray-cast-event-type.js
+++ b/src/platform/lumin-runtime/types/ray-cast-event-type.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
+
+import { RayCastEventType as luminRayCastEventType } from 'lumin';
+
+/**
+ * @exports RayCastEventType
+ * @description Represents RayCastEventType.
+ */
+export const RayCastEventType = {
+    'invalid': luminRayCastEventType.kInvalid,
+    'node-on-control-enter': luminRayCastEventType.kNodeOnControlEnter,
+    'node-on-control-exit': luminRayCastEventType.kNodeOnControlExit,
+    'node-on-control-move': luminRayCastEventType.kNodeOnControlMove,
+    'node-on-cursor-enter': luminRayCastEventType.kNodeOnCursorEnter,
+    'node-on-cursor-exit': luminRayCastEventType.kNodeOnCursorExit,
+    'node-on-cursor-move': luminRayCastEventType.kNodeOnCursorMove,
+    'node-on-head-enter': luminRayCastEventType.kNodeOnHeadEnter,
+    'node-on-head-exit': luminRayCastEventType.kNodeOnHeadExit,
+    'node-on-head-move': luminRayCastEventType.kNodeOnHeadMove,
+    'volume-on-control-enter': luminRayCastEventType.kVolumeOnControlEnter,
+    'volume-on-control-exit': luminRayCastEventType.kVolumeOnControlExit,
+    'volume-on-control-move': luminRayCastEventType.kVolumeOnControlMove,
+    'volume-on-head-enter': luminRayCastEventType.kVolumeOnHeadEnter,
+    'volume-on-head-exit': luminRayCastEventType.kVolumeOnHeadExit,
+    'volume-on-head-move': luminRayCastEventType.kVolumeOnHeadMove
+}


### PR DESCRIPTION
Add RayCastEventType and RayCastEventData support. RayCastEventType Indicates the type of Raycast event for Volumes or Nodes, and whether it involves Head, Control, or Cursor raycasts.
