### PR TITLE
Add ServerEvent.ServerEventType property

### DIFF
--- a/src/platform/lumin-runtime/types/event-data/server-event.js
+++ b/src/platform/lumin-runtime/types/event-data/server-event.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 import { ServerEvent as _ServerEvent } from 'lumin';
 import { EventData } from './event-data.js';
+import { ServerEventType } from '../server-event-type.js';
+import { extractor } from '../../utilities/extractor.js';
 
 export class ServerEvent extends EventData {
     constructor(nativeEvent) {
@@ -11,12 +13,12 @@ export class ServerEvent extends EventData {
         ]);
     }
 
-    // get PrismId() {
-    //     return this._nativeEvent.getPrismId();
-    // }
-
     get isInputEvent() {
         return this._nativeEvent.isInputEventType();
+    }
+
+    get ServerEventType() {
+        return extractor.getKeyByValue(ServerEventType, this._nativeEvent.getServerEventType());
     }
 
     static isSupported(event) {

--- a/src/platform/lumin-runtime/types/server-event-type.js
+++ b/src/platform/lumin-runtime/types/server-event-type.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
+
+import { ServerEventType as luminServerEventType } from 'lumin';
+
+/**
+ * @exports ServerEventType
+ * @description Represents ServerEventType.
+ */
+export const ServerEventType = {
+    'selection-event': luminServerEventType.kSelectionEvent,
+    'ray-cast-event': luminServerEventType.kRayCastEvent,
+    'video-event': luminServerEventType.kVideoEvent,
+    'video-subtitle-event': luminServerEventType.kVideoSubtitleEvent,
+    'video-timed-text-event': luminServerEventType.kVideoTimedTextEvent,
+    'sprite-animation-event': luminServerEventType.kSpriteAnimationEvent,
+    'key-input-event': luminServerEventType.kKeyInputEvent,
+    'gesture-input-event': luminServerEventType.kGestureInputEvent,
+    'control-pose-3-dof-input-event': luminServerEventType.kControlPose3DofInputEvent,
+    'control-pose-6-dof-input-event': luminServerEventType.kControlPose6DofInputEvent,
+    'control-touch-pad-input-event': luminServerEventType.kControlTouchPadInputEvent,
+    'transform-animation-event': luminServerEventType.kTransformAnimationEvent,
+    'world-plane-data': luminServerEventType.kWorldPlaneData,
+    'world-ray-hit': luminServerEventType.kWorldRayHit,
+    'system-event': luminServerEventType.kSystemEvent,
+    'physics-event': luminServerEventType.kPhysicsEvent,
+    'particle-event': luminServerEventType.kParticleEvent,
+    'audio-event': luminServerEventType.kAudioEvent,
+    'eye-tracking-event': luminServerEventType.kEyeTrackingEvent,
+    'animation-event': luminServerEventType.kAnimationEvent,
+    'animation-custom-event': luminServerEventType.kAnimationCustomEvent,
+    'animation-blend-setup-event': luminServerEventType.kAnimationBlendSetupEvent,
+    'privilege-event': luminServerEventType.kPrivilegeEvent,
+    'resource-event': luminServerEventType.kResourceEvent,
+    'world-mesh-block-data': luminServerEventType.kWorldMeshBlockData
+}


### PR DESCRIPTION
Add support for ServerEvent.ServerEventType property for the received server based events. The purpose of the property is to identify the actual event sub-type when used from `onEvent( serverEventData ) ` handler.
