### PR TITLE
Add offset to Transform and Orientation to ScrollBar

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/scroll-bar-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scroll-bar-builder.js
@@ -30,6 +30,13 @@ export class ScrollBarBuilder extends UiNodeBuilder {
 
         const element = MxsScrollBar.Create(prism, width, height);
 
+        Object.defineProperty(element, 'Orientation', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: ui.Orientation.kVertical
+        });
+
         const unapplied = this.excludeProperties(properties, ['width', 'height']);
 
         this.apply(element, undefined, unapplied);

--- a/src/platform/lumin-runtime/elements/builders/transform-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/transform-builder.js
@@ -45,13 +45,18 @@ export class TransformBuilder extends ElementBuilder {
 
         const element = prism.createTransformNode(localTransform);
 
+        // Attach 'offset' property
+        // the property is used when TransformNode is used by another node as content/model
+        Object.defineProperty(element, 'offset', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: [0, 0, 0]
+        });
+
         const unapplied = this.excludeProperties(properties, ['localTransform']);
 
         this.apply(element, undefined, unapplied);
-
-        // Attach 'offset' property
-        // the property is used when TransformNode is used by another node as content/model
-        element.offset = [0, 0, 0];
 
         return element;
     }


### PR DESCRIPTION
1. Adding `offset` property to the TransformNode before applying the properties.
2. Adding `Orientation` property to the ScrollBar. This property is required when ScrollBar is added to components like ScrollView.
