### PR TITLE
Regenerate TypeScript declarations with missing props, event handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,9 @@ declare module "magic-script-components" {
     weight?: FontWeight;
     boundsSize?: { boundsSize?: vec2; wrap?: boolean; };
     fontParameters?: { style?: FontStyle; weight?: FontWeight; fontSize?: number; tracking?: number; allCaps?: boolean; };
+    fontDescription?: FontDescription;
+    filePath?: string;
+    absolutePath?: boolean;
   }
 
   const Text: React.FC<TextProps>;
@@ -125,6 +128,9 @@ declare module "magic-script-components" {
     fontParameters?: { style?: FontStyle; weight?: FontWeight; fontSize?: number; tracking?: number; allCaps?: boolean; };
     width?: number;
     height?: number;
+    fontDescription?: FontDescription;
+    filePath?: string;
+    absolutePath?: boolean;
   }
 
   const TextEdit: React.FC<TextEditProps>;
@@ -201,6 +207,11 @@ declare module "magic-script-components" {
     renderResource?: number;
     width?: number;
     height?: number;
+    icon?: SystemIcon;
+    filePath?: string;
+    resourceId?: bigint;
+    absolutePath?: boolean;
+    useFrame?: boolean;
   }
 
   const Image: React.FC<ImageProps>;
@@ -374,6 +385,11 @@ declare module "magic-script-components" {
     gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
     size?: vec2;
     value?: number;
+    type?: LoadingSpinnerType;
+    id?: bigint;
+    path?: string;
+    height?: number;
+    determinate?: boolean;
   }
 
   const Spinner: React.FC<SpinnerProps>;
@@ -593,6 +609,8 @@ declare module "magic-script-components" {
   const DropdownList: React.FC<DropdownListProps>;
 
   interface DropdownListItemProps {
+    label?: string;
+    id?: number;
   }
 
   const DropdownListItem: React.FC<DropdownListItemProps>;
@@ -627,6 +645,8 @@ declare module "magic-script-components" {
     textColor?: vec4;
     textSize?: number;
     on?: boolean;
+    height?: number;
+    type?: ToggleType;
   }
 
   const Toggle: React.FC<ToggleProps>;
@@ -729,6 +749,7 @@ declare module "magic-script-components" {
     text?: string;
     textColor?: vec4;
     textSize?: number;
+    type?: EclipseLabelType;
   }
 
   const Tab: React.FC<TabProps>;
@@ -766,6 +787,11 @@ declare module "magic-script-components" {
     confirmText?: string;
     confirmIcon?: SystemIcon;
     expireTime?: number;
+    message?: string;
+    title?: string;
+    type?: DialogType;
+    layout?: DialogLayout;
+    scrolling?: boolean;
   }
 
   const Dialog: React.FC<DialogProps>;
@@ -877,6 +903,7 @@ declare module "magic-script-components" {
     iconIdleAnimation?: string;
     iconHoverPosition?: vec3;
     labelDisplayMode?: LabelDisplayMode;
+    iconSize?: PortalIconSize;
   }
 
   const PortalIcon: React.FC<PortalIconProps>;
@@ -907,6 +934,7 @@ declare module "magic-script-components" {
     eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
     gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
     color?: vec4;
+    height?: number;
   }
 
   const ColorPicker: React.FC<ColorPickerProps>;
@@ -939,6 +967,9 @@ declare module "magic-script-components" {
     color?: vec4;
     time?: string;
     showHint?: boolean;
+    label?: string;
+    labelSide?: Side;
+    defaultTime?: string;
   }
 
   const TimePicker: React.FC<TimePickerProps>;
@@ -971,6 +1002,11 @@ declare module "magic-script-components" {
     color?: vec4;
     date?: string;
     showHint?: boolean;
+    label?: string;
+    labelSide?: Side;
+    defaultDate?: string;
+    yearMin?: number;
+    yearMax?: number;
   }
 
   const DatePicker: React.FC<DatePickerProps>;
@@ -1000,6 +1036,7 @@ declare module "magic-script-components" {
     gravityWellEnabled?: boolean;
     eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
     gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+    radius?: number;
   }
 
   const CircleConfirmation: React.FC<CircleConfirmationProps>;
@@ -1065,6 +1102,10 @@ declare module "magic-script-components" {
     modelResourceId?: number;
     animation?: { resourceId?: number; name?: string; paused?: boolean; loops?: number; };
     texture?: { textureId?: number; textureSlot?: string; materialName?: string; };
+    modelPath?: string;
+    materialPath?: string;
+    importScale?: number;
+    texturePaths?: number[];
   }
 
   const Model: React.FC<ModelProps>;
@@ -1108,6 +1149,7 @@ declare module "magic-script-components" {
     texCoords?: vec4;
     viewMode?: ViewMode;
     size?: vec2;
+    subTexture?: string | number;
   }
 
   const Quad: React.FC<QuadProps>;
@@ -1193,6 +1235,13 @@ declare module "magic-script-components" {
     spatialSoundPosition?: { channel?: number; channelPosition?: vec3; };
     spatialSoundRadiation?: { channel?: number; innerAngle?: number; outerAngle?: number; outerGain?: number; outerGainHf?: number; };
     spatialSoundRoomSendLevels?: { channel?: number; gain?: number; gainHf?: number; gainLf?: number; gainMf?: number; };
+    fileName?: string;
+    loadFile?: boolean;
+    absolutePath?: boolean;
+    descriptor?: number;
+    basePath?: string;
+    autoDestroy?: boolean;
+    dynamicDecode?: boolean;
   }
 
   const Audio: React.FC<AudioProps>;
@@ -1295,6 +1344,20 @@ declare module "magic-script-components" {
 
   type FontWeight = 'extra-light' | 'light' | 'regular' | 'medium' | 'bold' | 'extra-bold';
 
+  type FontDescription = {
+    advanceDirection: AdvanceDirection,
+    flowDirection: FlowDirection,
+    tileSize: number,
+    quality?: Quality,
+    minAlpha?: number
+  };
+
+  type AdvanceDirection = 'down' | 'left' | 'right' | 'up';
+
+  type FlowDirection = 'above' | 'below' | 'left' | 'right';
+
+  type Quality = 'enh1' | 'enh1-aa' | 'enh1-fast' | 'enh2' | 'enh3' | 'exper' | 'fast' | 'std' | 'std-0';
+
   type CursorEdgeScrollMode = 'always' | 'auto' | 'never';
 
   type TextEntryMode = 'email' | 'none' | 'normal' | 'numeric' | 'url';
@@ -1305,19 +1368,31 @@ declare module "magic-script-components" {
 
   type ScrollDirection = 'horizontal' | 'vertical';
 
+  type LoadingSpinnerType = 'sprite-animation' | 'particle-package';
+
+  type ToggleType = 'default' | 'checkbox' | 'radio';
+
   type PanelCursorTransitionType = 'center' | 'closest-edge' | 'initial-position';
 
   type Side = 'bottom' | 'left' | 'right' | 'top';
 
   type PanelEdgeConstraintLevel = 'heavy' | 'impassable' | 'light' | 'manual' | 'medium' | 'none';
 
+  type EclipseLabelType = 'B1' | 'B2' | 'B3' | 'B4' | 'C1' | 'C2' | 'C3' | 'C4' | 'T1' | 'T2' | 'T3' | 'T4' | 'T5' | 'T6' | 'T7';
+
   type EclipseButtonType = 'icon' | 'icon-with-label' | 'text' | 'text-with-icon';
 
   type SystemIcon = 'actions' | 'actions-left' | 'actions-off' | 'actions-right' | 'add' | 'address-book' | 'album-add' | 'album-remove' | 'alphabetical' | 'analytics' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up' | 'auto-placement' | 'backspace' | 'battery' | 'block' | 'block-camera' | 'block-cookie' | 'block-location' | 'block-microphone' | 'bluetooth' | 'bluetooth-off' | 'bookmark' | 'bookmark-add' | 'brightness' | 'calendar' | 'camera' | 'camera-iris' | 'carriage-return' | 'chat' | 'check' | 'check-selection' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'close' | 'closed-caption' | 'cloud' | 'cloud-off' | 'collection' | 'controller' | 'cookie' | 'copy' | 'credit-card' | 'cut' | 'cv-camera-privilege' | 'do-not-disturb' | 'dot' | 'download' | 'download-cloud' | 'dropdown' | 'edit' | 'effects-palette' | 'eject' | 'emoji' | 'enter' | 'exit' | 'extraction' | 'eye-tracking' | 'fast-forward' | 'fast-forward-ten-second' | 'file' | 'filter' | 'flag' | 'flag-china' | 'flag-france' | 'flag-germany' | 'flag-japan' | 'flag-south-korea' | 'flag-uk' | 'flag-usa' | 'follow' | 'frame' | 'game-controller' | 'generic-three-dimensional' | 'grid' | 'hamburger' | 'hand-orientation-left' | 'hand-orientation-right' | 'heart' | 'heart-add' | 'help' | 'history' | 'home' | 'image' | 'info' | 'keyboard' | 'keyboard-capital' | 'keyboard-language' | 'keyboard-letter' | 'keyboard-number' | 'link' | 'list-view' | 'local-area-server' | 'marquee-selection' | 'merge' | 'mesh' | 'microphone' | 'microphone-mute' | 'minimize' | 'mobile' | 'more' | 'move' | 'multiple-selection' | 'music' | 'music-pause' | 'music-play' | 'network-server' | 'next' | 'notification' | 'object-recognition' | 'open-with' | 'origin' | 'passable-world' | 'paste' | 'pause' | 'permission' | 'person' | 'person-add' | 'person-block' | 'person-follow' | 'person-three' | 'person-two' | 'person-un-follow' | 'person-voip' | 'phone' | 'phone-end-call' | 'phone-incoming-call' | 'phone-switch-call' | 'pin' | 'placeholder-bluetooth' | 'play' | 'playlist-repeat-off' | 'playlist-repeat-on' | 'playlist-repeat-song' | 'playlist-shuffle' | 'playlist-shuffle-off' | 'power' | 'previous' | 'privacy' | 'private-view' | 'public-view' | 'rearrange' | 'refresh' | 'replay' | 'report' | 'resize' | 'restore-media' | 'revolver' | 'rewind-ten-second' | 'screenshot' | 'search' | 'security-lock' | 'security-not-secure' | 'security-unlock' | 'send' | 'settings' | 'share' | 'share-screen' | 'shift-disabled' | 'shift-enabled' | 'shift-enabled-permanent' | '6-dof' | 'sleep' | 'slide-show' | 'snooze' | 'space' | 'star' | 'stop' | 'stream' | 'stream-off' | 'summon' | 'tablet' | 'tab-new' | 'tab-new-image' | 'tab-view-all' | 'tag' | 'text' | 'thumbs-down' | 'thumbs-down-left' | 'thumbs-down-right' | 'thumbs-up' | 'thumbs-up-left' | 'thumbs-up-right' | 'top-chart' | 'trash' | 'undo-reply' | 'unknown-device' | 'update' | 'upload' | 'upload-cloud' | 'view' | 'view-source' | 'voice-feedback' | 'voip' | 'volume' | 'volume-mute' | 'warning' | 'web-xr' | 'wifi' | 'wifi-no-bar' | 'wifi-no-signal' | 'wifi-off' | 'wifi-one-bar' | 'wifi-secure' | 'wifi-secure-no-bar' | 'wifi-secure-no-signal' | 'wifi-secure-one-bar' | 'wifi-unknown' | 'window-new' | 'window-pop-up-block' | 'window-view-all' | 'work' | 'workspaces' | 'zoom-in' | 'zoom-out';
 
+  type DialogType = 'custom' | 'timed' | 'no-action' | 'single-action' | 'dual-action';
+
+  type DialogLayout = 'standard' | 'wide';
+
   type WebViewAction = 'back' | 'forward' | 'reload';
 
   type LabelDisplayMode = 'always' | 'hover';
+
+  type PortalIconSize = 'extra-large' | 'large' | 'medium' | 'small' | 'extra-small';
 
   type ShaderType = 'diffuse-normal-spec' | 'pbr' | 'unlit-textured';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,6 @@ declare module "magic-script-components" {
   const View: React.FC<ViewProps>;
 
   interface TextProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -43,7 +42,6 @@ declare module "magic-script-components" {
   const Text: React.FC<TextProps>;
 
   interface TextEditProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -73,7 +71,6 @@ declare module "magic-script-components" {
   const TextEdit: React.FC<TextEditProps>;
 
   interface ButtonProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -264,7 +261,6 @@ declare module "magic-script-components" {
   const DropdownListItem: React.FC<DropdownListItemProps>;
 
   interface ToggleProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -297,7 +293,6 @@ declare module "magic-script-components" {
   const Panel: React.FC<PanelProps>;
 
   interface TabProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -307,7 +302,6 @@ declare module "magic-script-components" {
   const Tab: React.FC<TabProps>;
 
   interface DialogProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     buttonType?: EclipseButtonType;
     cancelText?: string;
@@ -347,7 +341,6 @@ declare module "magic-script-components" {
   const WebView: React.FC<WebViewProps>;
 
   interface PortalIconProps extends ViewProps, EventHandlerProps {
-    children?: any;
     text?: string;
     textColor?: vec4;
     textSize?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,22 +8,7 @@ declare module "magic-script-components" {
     volumeSize: vec3;
   }
 
-  interface ViewProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface ViewProps extends ContentProps, EventHandlerProps {
     alignment?: Alignment;
     activateResponse?: FocusRequest;
     renderingLayer?: RenderingLayer;
@@ -37,31 +22,7 @@ declare module "magic-script-components" {
 
   const View: React.FC<ViewProps>;
 
-  interface TextProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface TextProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -81,31 +42,7 @@ declare module "magic-script-components" {
 
   const Text: React.FC<TextProps>;
 
-  interface TextEditProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface TextEditProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -135,31 +72,7 @@ declare module "magic-script-components" {
 
   const TextEdit: React.FC<TextEditProps>;
 
-  interface ButtonProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ButtonProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -173,31 +86,7 @@ declare module "magic-script-components" {
 
   const Button: React.FC<ButtonProps>;
 
-  interface ImageProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ImageProps extends ViewProps, EventHandlerProps {
     ui?: boolean;
     opaque?: boolean;
     color?: vec4;
@@ -215,31 +104,7 @@ declare module "magic-script-components" {
 
   const Image: React.FC<ImageProps>;
 
-  interface ScrollBarProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ScrollBarProps extends ViewProps, EventHandlerProps {
     thumbSize?: number;
     thumbPosition?: number;
     orientation?: Orientation;
@@ -249,31 +114,7 @@ declare module "magic-script-components" {
 
   const ScrollBar: React.FC<ScrollBarProps>;
 
-  interface ScrollViewProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ScrollViewProps extends ViewProps, EventHandlerProps {
     scrollBarVisibility?: ScrollBarVisibility;
     scrollDirection?: ScrollDirection;
     scrollMask?: number;
@@ -327,61 +168,13 @@ declare module "magic-script-components" {
 
   const ListView: React.FC<ListViewProps>;
 
-  interface ListViewItemProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ListViewItemProps extends ViewProps, EventHandlerProps {
     backgroundColor?: vec4;
   }
 
   const ListViewItem: React.FC<ListViewItemProps>;
 
-  interface SpinnerProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface SpinnerProps extends ViewProps, EventHandlerProps {
     size?: vec2;
     value?: number;
     type?: LoadingSpinnerType;
@@ -393,31 +186,7 @@ declare module "magic-script-components" {
 
   const Spinner: React.FC<SpinnerProps>;
 
-  interface SliderProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface SliderProps extends ViewProps, EventHandlerProps {
     min?: number;
     max?: number;
     value?: number;
@@ -427,31 +196,7 @@ declare module "magic-script-components" {
 
   const Slider: React.FC<SliderProps>;
 
-  interface ProgressBarProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ProgressBarProps extends ViewProps, EventHandlerProps {
     progressColor?: { beginColor?: vec4; endColor?: vec4; };
     min?: number;
     max?: number;
@@ -462,31 +207,7 @@ declare module "magic-script-components" {
 
   const ProgressBar: React.FC<ProgressBarProps>;
 
-  interface GridLayoutProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface GridLayoutProps extends ViewProps, EventHandlerProps {
     defaultItemAlignment?: Alignment;
     defaultItemPadding?: vec4;
     itemPadding?: vec4;
@@ -499,31 +220,7 @@ declare module "magic-script-components" {
 
   const GridLayout: React.FC<GridLayoutProps>;
 
-  interface LinearLayoutProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface LinearLayoutProps extends ViewProps, EventHandlerProps {
     defaultItemAlignment?: Alignment;
     defaultItemPadding?: vec4;
     itemPadding?: vec4;
@@ -535,31 +232,7 @@ declare module "magic-script-components" {
 
   const LinearLayout: React.FC<LinearLayoutProps>;
 
-  interface RectLayoutProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface RectLayoutProps extends ViewProps, EventHandlerProps {
     contentAlignment?: Alignment;
     width?: number;
     height?: number;
@@ -567,31 +240,7 @@ declare module "magic-script-components" {
 
   const RectLayout: React.FC<RectLayoutProps>;
 
-  interface DropdownListProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface DropdownListProps extends ViewProps, EventHandlerProps {
     text?: string;
     textColor?: vec4;
     textSize?: number;
@@ -614,31 +263,7 @@ declare module "magic-script-components" {
 
   const DropdownListItem: React.FC<DropdownListItemProps>;
 
-  interface ToggleProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ToggleProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -650,31 +275,7 @@ declare module "magic-script-components" {
 
   const Toggle: React.FC<ToggleProps>;
 
-  interface ToggleGroupProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ToggleGroupProps extends ViewProps, EventHandlerProps {
     allowMultipleOn?: boolean;
     allowAllOff?: boolean;
     allTogglesOff?: boolean;
@@ -682,31 +283,7 @@ declare module "magic-script-components" {
 
   const ToggleGroup: React.FC<ToggleGroupProps>;
 
-  interface PanelProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface PanelProps extends ViewProps, EventHandlerProps {
     cursorConstrained?: boolean;
     cursorInitialPosition?: vec3;
     cursorTransitionType?: PanelCursorTransitionType;
@@ -719,31 +296,7 @@ declare module "magic-script-components" {
 
   const Panel: React.FC<PanelProps>;
 
-  interface TabProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface TabProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -753,31 +306,7 @@ declare module "magic-script-components" {
 
   const Tab: React.FC<TabProps>;
 
-  interface DialogProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface DialogProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     buttonType?: EclipseButtonType;
@@ -795,31 +324,7 @@ declare module "magic-script-components" {
 
   const Dialog: React.FC<DialogProps>;
 
-  interface PageViewProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface PageViewProps extends ViewProps, EventHandlerProps {
     defaultPageAlignment?: Alignment;
     defaultPagePadding?: vec4;
     visiblePage?: number;
@@ -831,31 +336,7 @@ declare module "magic-script-components" {
 
   const PageView: React.FC<PageViewProps>;
 
-  interface WebViewProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface WebViewProps extends ViewProps, EventHandlerProps {
     url?: string;
     action?: WebViewAction;
     scrollBy?: vec2;
@@ -865,31 +346,7 @@ declare module "magic-script-components" {
 
   const WebView: React.FC<WebViewProps>;
 
-  interface PortalIconProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface PortalIconProps extends ViewProps, EventHandlerProps {
     children?: any;
     text?: string;
     textColor?: vec4;
@@ -907,62 +364,14 @@ declare module "magic-script-components" {
 
   const PortalIcon: React.FC<PortalIconProps>;
 
-  interface ColorPickerProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface ColorPickerProps extends ViewProps, EventHandlerProps {
     color?: vec4;
     height?: number;
   }
 
   const ColorPicker: React.FC<ColorPickerProps>;
 
-  interface TimePickerProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface TimePickerProps extends ViewProps, EventHandlerProps {
     color?: vec4;
     time?: string;
     showHint?: boolean;
@@ -973,31 +382,7 @@ declare module "magic-script-components" {
 
   const TimePicker: React.FC<TimePickerProps>;
 
-  interface DatePickerProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface DatePickerProps extends ViewProps, EventHandlerProps {
     color?: vec4;
     date?: string;
     showHint?: boolean;
@@ -1010,31 +395,7 @@ declare module "magic-script-components" {
 
   const DatePicker: React.FC<DatePickerProps>;
 
-  interface CircleConfirmationProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    alignment?: Alignment;
-    activateResponse?: FocusRequest;
-    renderingLayer?: RenderingLayer;
-    enabled?: boolean;
-    eventPassThrough?: boolean;
-    eventPassThroughChildren?: boolean;
-    gravityWellEnabled?: boolean;
-    eventSoundId?: { soundEvent?: SoundEvent; soundName?: string; };
-    gravityWellProperties?: { shape?: { size?: vec2; offset?: vec3; roundness?: number; }; snap?: GravityWellSnap; internalSnap?: boolean; };
+  interface CircleConfirmationProps extends ViewProps, EventHandlerProps {
     radius?: number;
   }
 
@@ -1060,22 +421,7 @@ declare module "magic-script-components" {
 
   const Content: React.FC<ContentProps>;
 
-  interface ModelProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface ModelProps extends ContentProps, EventHandlerProps {
     bloomStrength?: number;
     color?: vec4;
     drmContent?: boolean;
@@ -1109,22 +455,7 @@ declare module "magic-script-components" {
 
   const Model: React.FC<ModelProps>;
 
-  interface QuadProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface QuadProps extends ContentProps, EventHandlerProps {
     bloomStrength?: number;
     color?: vec4;
     drmContent?: boolean;
@@ -1153,45 +484,7 @@ declare module "magic-script-components" {
 
   const Quad: React.FC<QuadProps>;
 
-  interface VideoProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
-    bloomStrength?: number;
-    color?: vec4;
-    drmContent?: boolean;
-    shader?: ShaderType;
-    renderingLayer?: RenderingLayer;
-    backFaceCulls?: { on?: boolean; renderStateIndex?: number; };
-    blooms?: { on?: boolean; renderStateIndex?: number; };
-    castsShadows?: { on?: boolean; renderStateIndex?: number; };
-    frontFaceCulls?: { on?: boolean; renderStateIndex?: number; };
-    isOpaque?: { on?: boolean; renderStateIndex?: number; };
-    isUI?: { on?: boolean; renderStateIndex?: number; };
-    pushesStencil?: { on?: boolean; renderStateIndex?: number; };
-    readsClip?: { on?: boolean; renderStateIndex?: number; };
-    readsDepth?: { on?: boolean; renderStateIndex?: number; };
-    receivesLight?: { on?: boolean; renderStateIndex?: number; };
-    receivesShadows?: { on?: boolean; renderStateIndex?: number; };
-    writesColor?: { on?: boolean; renderStateIndex?: number; };
-    writesDepth?: { on?: boolean; renderStateIndex?: number; };
-    writesStencil?: { on?: boolean; renderStateIndex?: number; };
-    renderResourceId?: number;
-    texCoords?: vec4;
-    viewMode?: ViewMode;
-    size?: vec2;
+  interface VideoProps extends QuadProps, EventHandlerProps {
     looping?: boolean;
     timedTextPath?: string;
     videoPath?: string;
@@ -1205,22 +498,7 @@ declare module "magic-script-components" {
 
   const Video: React.FC<VideoProps>;
 
-  interface AudioProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface AudioProps extends ContentProps, EventHandlerProps {
     action?: AudioAction;
     soundLooping?: boolean;
     soundMute?: boolean;
@@ -1245,22 +523,7 @@ declare module "magic-script-components" {
 
   const Audio: React.FC<AudioProps>;
 
-  interface LightProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface LightProps extends ContentProps, EventHandlerProps {
     color?: vec4;
     intensity?: number;
     range?: number;
@@ -1272,22 +535,7 @@ declare module "magic-script-components" {
 
   const Light: React.FC<LightProps>;
 
-  interface LineProps extends EventHandlerProps {
-    name?: string;
-    parentedBoneName?: string;
-    skipRaycast?: boolean;
-    triggerable?: boolean;
-    visible?: boolean;
-    visibilityInherited?: boolean;
-    anchorPosition?: vec3;
-    localPosition?: vec3;
-    localRotation?: quat;
-    localScale?: vec3;
-    localTransform?: mat4;
-    cursorHoverState?: CursorHoverState;
-    offset?: vec3;
-    padding?: vec4;
-    itemAlignment?: Alignment;
+  interface LineProps extends ContentProps, EventHandlerProps {
     bloomStrength?: number;
     color?: vec4;
     drmContent?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,63 @@ declare module "magic-script-components" {
     volumeSize: vec3;
   }
 
-  interface ViewProps {
+  interface EventHandlerProps {
+    onActivate?: (eventData: UiEventData) => void;
+    onClick?: (eventData: UiEventData) => void;
+    onPress?: (eventData: UiEventData) => void;
+    onLongPress?: (eventData: UiEventData) => void;
+    onRelease?: (eventData: UiEventData) => void;
+    onHoverEnter?: (eventData: UiEventData) => void;
+    onHoverExit?: (eventData: UiEventData) => void;
+    onHoverMove?: (eventData: UiEventData) => void;
+    onEnabled?: (eventData: UiEventData) => void;
+    onDisabled?: (eventData: UiEventData) => void;
+    onFocusGained?: (eventData: UiEventData) => void;
+    onFocusLost?: (eventData: UiEventData) => void;
+    onFocusInput?: (eventData: UiEventData) => void;
+    onUpdate?: (eventData: UiEventData) => void;
+    onDelete?: (eventData: UiEventData) => void;
+    onCharacterEnter?: (eventData: TextEditEventData) => void;
+    onKeyboardEvent?: (eventData: TextEditEventData) => void;
+    onTextChanged?: (eventData: TextEditEventData) => void;
+    onSliderChanged?: (eventData: SliderEventData) => void;
+    onScrollChanged?: (eventData: ScrollViewEventData) => void;
+    onProgressBarChanged?: (eventData: ProgressBarEventData) => void;
+    onListVisibilityChanged?: (eventData: DropDownListEventData) => void;
+    onSelectionChanged?: (eventData: DropDownListEventData) => void;
+    onToggleChanged?: (eventData: ToggleEventData) => void;
+    onCursorEdge?: (eventData: UiEventData) => void;
+    onCursorOffEdge?: (eventData: UiEventData) => void;
+    onPanelEnter?: (eventData: UiEventData) => void;
+    onPanelExit?: (eventData: UiEventData) => void;
+    onDialogCanceled?: (eventData: UiEventData) => void;
+    onDialogConfirmed?: (eventData: UiEventData) => void;
+    onDialogTimeExpired?: (eventData: UiEventData) => void;
+    onColorCanceled?: (eventData: ColorPickerEventData) => void;
+    onColorChanged?: (eventData: ColorPickerEventData) => void;
+    onColorConfirmed?: (eventData: ColorPickerEventData) => void;
+    onTimeChanged?: (eventData: TimePickerEventData) => void;
+    onTimeConfirmed?: (eventData: TimePickerEventData) => void;
+    onDateChanged?: (eventData: DatePickerEventData) => void;
+    onDateConfirmed?: (eventData: DatePickerEventData) => void;
+    onConfirmationCanceled?: (eventData: CircleConfirmationEventData) => void;
+    onConfirmationCompleted?: (eventData: CircleConfirmationEventData) => void;
+    onConfirmationUpdated?: (eventData: CircleConfirmationEventData) => void;
+  }
+
+  type UiEventData = any;
+  type TextEditEventData = any;
+  type SliderEventData = any;
+  type ScrollViewEventData = any;
+  type ProgressBarEventData = any;
+  type DropDownListEventData = any;
+  type ToggleEventData = any;
+  type ColorPickerEventData = any;
+  type TimePickerEventData = any;
+  type DatePickerEventData = any;
+  type CircleConfirmationEventData = any;
+
+  interface ViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -37,7 +93,7 @@ declare module "magic-script-components" {
 
   const View: React.FC<ViewProps>;
 
-  interface TextProps {
+  interface TextProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -81,7 +137,7 @@ declare module "magic-script-components" {
 
   const Text: React.FC<TextProps>;
 
-  interface TextEditProps {
+  interface TextEditProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -135,7 +191,7 @@ declare module "magic-script-components" {
 
   const TextEdit: React.FC<TextEditProps>;
 
-  interface ButtonProps {
+  interface ButtonProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -169,12 +225,11 @@ declare module "magic-script-components" {
     width?: number;
     height?: number;
     roundness?: number;
-    onClick?: (event: any) => void;
   }
 
   const Button: React.FC<ButtonProps>;
 
-  interface ImageProps {
+  interface ImageProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -216,7 +271,7 @@ declare module "magic-script-components" {
 
   const Image: React.FC<ImageProps>;
 
-  interface ScrollBarProps {
+  interface ScrollBarProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -250,7 +305,7 @@ declare module "magic-script-components" {
 
   const ScrollBar: React.FC<ScrollBarProps>;
 
-  interface ScrollViewProps {
+  interface ScrollViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -286,7 +341,7 @@ declare module "magic-script-components" {
 
   const ScrollView: React.FC<ScrollViewProps>;
 
-  interface ListViewProps {
+  interface ListViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -328,7 +383,7 @@ declare module "magic-script-components" {
 
   const ListView: React.FC<ListViewProps>;
 
-  interface ListViewItemProps {
+  interface ListViewItemProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -358,7 +413,7 @@ declare module "magic-script-components" {
 
   const ListViewItem: React.FC<ListViewItemProps>;
 
-  interface SpinnerProps {
+  interface SpinnerProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -394,7 +449,7 @@ declare module "magic-script-components" {
 
   const Spinner: React.FC<SpinnerProps>;
 
-  interface SliderProps {
+  interface SliderProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -428,7 +483,7 @@ declare module "magic-script-components" {
 
   const Slider: React.FC<SliderProps>;
 
-  interface ProgressBarProps {
+  interface ProgressBarProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -463,7 +518,7 @@ declare module "magic-script-components" {
 
   const ProgressBar: React.FC<ProgressBarProps>;
 
-  interface GridLayoutProps {
+  interface GridLayoutProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -500,7 +555,7 @@ declare module "magic-script-components" {
 
   const GridLayout: React.FC<GridLayoutProps>;
 
-  interface LinearLayoutProps {
+  interface LinearLayoutProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -536,7 +591,7 @@ declare module "magic-script-components" {
 
   const LinearLayout: React.FC<LinearLayoutProps>;
 
-  interface RectLayoutProps {
+  interface RectLayoutProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -568,7 +623,7 @@ declare module "magic-script-components" {
 
   const RectLayout: React.FC<RectLayoutProps>;
 
-  interface DropdownListProps {
+  interface DropdownListProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -608,14 +663,14 @@ declare module "magic-script-components" {
 
   const DropdownList: React.FC<DropdownListProps>;
 
-  interface DropdownListItemProps {
+  interface DropdownListItemProps extends EventHandlerProps {
     label?: string;
     id?: number;
   }
 
   const DropdownListItem: React.FC<DropdownListItemProps>;
 
-  interface ToggleProps {
+  interface ToggleProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -651,7 +706,7 @@ declare module "magic-script-components" {
 
   const Toggle: React.FC<ToggleProps>;
 
-  interface ToggleGroupProps {
+  interface ToggleGroupProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -683,7 +738,7 @@ declare module "magic-script-components" {
 
   const ToggleGroup: React.FC<ToggleGroupProps>;
 
-  interface PanelProps {
+  interface PanelProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -720,7 +775,7 @@ declare module "magic-script-components" {
 
   const Panel: React.FC<PanelProps>;
 
-  interface TabProps {
+  interface TabProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -754,7 +809,7 @@ declare module "magic-script-components" {
 
   const Tab: React.FC<TabProps>;
 
-  interface DialogProps {
+  interface DialogProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -796,7 +851,7 @@ declare module "magic-script-components" {
 
   const Dialog: React.FC<DialogProps>;
 
-  interface PageViewProps {
+  interface PageViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -832,7 +887,7 @@ declare module "magic-script-components" {
 
   const PageView: React.FC<PageViewProps>;
 
-  interface WebViewProps {
+  interface WebViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -866,7 +921,7 @@ declare module "magic-script-components" {
 
   const WebView: React.FC<WebViewProps>;
 
-  interface PortalIconProps {
+  interface PortalIconProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -908,7 +963,7 @@ declare module "magic-script-components" {
 
   const PortalIcon: React.FC<PortalIconProps>;
 
-  interface ColorPickerProps {
+  interface ColorPickerProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -939,7 +994,7 @@ declare module "magic-script-components" {
 
   const ColorPicker: React.FC<ColorPickerProps>;
 
-  interface TimePickerProps {
+  interface TimePickerProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -974,7 +1029,7 @@ declare module "magic-script-components" {
 
   const TimePicker: React.FC<TimePickerProps>;
 
-  interface DatePickerProps {
+  interface DatePickerProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1011,7 +1066,7 @@ declare module "magic-script-components" {
 
   const DatePicker: React.FC<DatePickerProps>;
 
-  interface CircleConfirmationProps {
+  interface CircleConfirmationProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1041,7 +1096,7 @@ declare module "magic-script-components" {
 
   const CircleConfirmation: React.FC<CircleConfirmationProps>;
 
-  interface ContentProps {
+  interface ContentProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1061,7 +1116,7 @@ declare module "magic-script-components" {
 
   const Content: React.FC<ContentProps>;
 
-  interface ModelProps {
+  interface ModelProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1110,7 +1165,7 @@ declare module "magic-script-components" {
 
   const Model: React.FC<ModelProps>;
 
-  interface QuadProps {
+  interface QuadProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1154,7 +1209,7 @@ declare module "magic-script-components" {
 
   const Quad: React.FC<QuadProps>;
 
-  interface VideoProps {
+  interface VideoProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1206,7 +1261,7 @@ declare module "magic-script-components" {
 
   const Video: React.FC<VideoProps>;
 
-  interface AudioProps {
+  interface AudioProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1246,7 +1301,7 @@ declare module "magic-script-components" {
 
   const Audio: React.FC<AudioProps>;
 
-  interface LightProps {
+  interface LightProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1273,7 +1328,7 @@ declare module "magic-script-components" {
 
   const Light: React.FC<LightProps>;
 
-  interface LineProps {
+  interface LineProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
     skipRaycast?: boolean;
@@ -1405,3 +1460,5 @@ declare module "magic-script-components" {
   type LightType = 'directional' | 'point' | 'spot';
 
 }
+
+declare function print(...args: any[]): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -1359,7 +1359,10 @@ declare module "magic-script-components" {
   // Event Data:
   // --------------------------------------------------------------------------------
 
-  interface UiEventData {
+  interface EventData {
+  }
+
+  interface NodeEventData extends EventData {
     AABB?: any;
     AnchorPosition?: any;
     ChildCount?: any;
@@ -1372,11 +1375,17 @@ declare module "magic-script-components" {
     NodeId?: any;
     ParentedBoneName?: any;
     PrismId?: any;
+  }
+
+  interface TransformNodeEventData extends NodeEventData {
     LocalPosition?: any;
     LocalRotation?: any;
     LocalScale?: any;
     PrismPosition?: any;
     WorldPosition?: any;
+  }
+
+  interface UiEventData extends TransformNodeEventData {
     Alignment?: any;
     Enabled?: any;
     EventPassThrough?: any;
@@ -1386,141 +1395,28 @@ declare module "magic-script-components" {
     RenderingLayer?: any;
   }
 
-  interface TextEditEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface TextEditEventData extends UiEventData {
     Text?: any;
   }
 
-  interface SliderEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface SliderEventData extends UiEventData {
     Max?: any;
     Min?: any;
     Value?: any;
   }
 
-  interface ScrollViewEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface ScrollViewEventData extends UiEventData {
     ScrollValue?: any;
   }
 
-  interface ProgressBarEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface ProgressBarEventData extends UiEventData {
     Max?: any;
     Min?: any;
     Value?: any;
     ProgressColor?: any;
   }
 
-  interface DropDownListEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
+  interface DropDownListEventData extends UiEventData {
     Alignment?: any;
     Enabled?: any;
     EventPassThrough?: any;
@@ -1530,148 +1426,28 @@ declare module "magic-script-components" {
     RenderingLayer?: any;
   }
 
-  interface ToggleEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface ToggleEventData extends UiEventData {
     On?: any;
     Text?: any;
     TextColor?: any;
     TextSize?: any;
   }
 
-  interface ColorPickerEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface ColorPickerEventData extends UiEventData {
     Color?: any;
   }
 
-  interface TimePickerEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface TimePickerEventData extends UiEventData {
     Time?: any;
     TimeString?: any;
   }
 
-  interface DatePickerEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface DatePickerEventData extends UiEventData {
     Date?: any;
     DateString?: any;
   }
 
-  interface CircleConfirmationEventData {
-    AABB?: any;
-    AnchorPosition?: any;
-    ChildCount?: any;
-    CurrentPrismTransform?: any;
-    CurrentWorldTransform?: any;
-    CursorHoverState?: any;
-    LocalAABB?: any;
-    LocalTransform?: any;
-    Name?: any;
-    NodeId?: any;
-    ParentedBoneName?: any;
-    PrismId?: any;
-    LocalPosition?: any;
-    LocalRotation?: any;
-    LocalScale?: any;
-    PrismPosition?: any;
-    WorldPosition?: any;
-    Alignment?: any;
-    Enabled?: any;
-    EventPassThrough?: any;
-    EventSoundID?: any;
-    GravityWellEnabled?: any;
-    GravityWellProperties?: any;
-    RenderingLayer?: any;
+  interface CircleConfirmationEventData extends UiEventData {
     Angle?: any;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,62 +8,6 @@ declare module "magic-script-components" {
     volumeSize: vec3;
   }
 
-  interface EventHandlerProps {
-    onActivate?: (eventData: UiEventData) => void;
-    onClick?: (eventData: UiEventData) => void;
-    onPress?: (eventData: UiEventData) => void;
-    onLongPress?: (eventData: UiEventData) => void;
-    onRelease?: (eventData: UiEventData) => void;
-    onHoverEnter?: (eventData: UiEventData) => void;
-    onHoverExit?: (eventData: UiEventData) => void;
-    onHoverMove?: (eventData: UiEventData) => void;
-    onEnabled?: (eventData: UiEventData) => void;
-    onDisabled?: (eventData: UiEventData) => void;
-    onFocusGained?: (eventData: UiEventData) => void;
-    onFocusLost?: (eventData: UiEventData) => void;
-    onFocusInput?: (eventData: UiEventData) => void;
-    onUpdate?: (eventData: UiEventData) => void;
-    onDelete?: (eventData: UiEventData) => void;
-    onCharacterEnter?: (eventData: TextEditEventData) => void;
-    onKeyboardEvent?: (eventData: TextEditEventData) => void;
-    onTextChanged?: (eventData: TextEditEventData) => void;
-    onSliderChanged?: (eventData: SliderEventData) => void;
-    onScrollChanged?: (eventData: ScrollViewEventData) => void;
-    onProgressBarChanged?: (eventData: ProgressBarEventData) => void;
-    onListVisibilityChanged?: (eventData: DropDownListEventData) => void;
-    onSelectionChanged?: (eventData: DropDownListEventData) => void;
-    onToggleChanged?: (eventData: ToggleEventData) => void;
-    onCursorEdge?: (eventData: UiEventData) => void;
-    onCursorOffEdge?: (eventData: UiEventData) => void;
-    onPanelEnter?: (eventData: UiEventData) => void;
-    onPanelExit?: (eventData: UiEventData) => void;
-    onDialogCanceled?: (eventData: UiEventData) => void;
-    onDialogConfirmed?: (eventData: UiEventData) => void;
-    onDialogTimeExpired?: (eventData: UiEventData) => void;
-    onColorCanceled?: (eventData: ColorPickerEventData) => void;
-    onColorChanged?: (eventData: ColorPickerEventData) => void;
-    onColorConfirmed?: (eventData: ColorPickerEventData) => void;
-    onTimeChanged?: (eventData: TimePickerEventData) => void;
-    onTimeConfirmed?: (eventData: TimePickerEventData) => void;
-    onDateChanged?: (eventData: DatePickerEventData) => void;
-    onDateConfirmed?: (eventData: DatePickerEventData) => void;
-    onConfirmationCanceled?: (eventData: CircleConfirmationEventData) => void;
-    onConfirmationCompleted?: (eventData: CircleConfirmationEventData) => void;
-    onConfirmationUpdated?: (eventData: CircleConfirmationEventData) => void;
-  }
-
-  type UiEventData = any;
-  type TextEditEventData = any;
-  type SliderEventData = any;
-  type ScrollViewEventData = any;
-  type ProgressBarEventData = any;
-  type DropDownListEventData = any;
-  type ToggleEventData = any;
-  type ColorPickerEventData = any;
-  type TimePickerEventData = any;
-  type DatePickerEventData = any;
-  type CircleConfirmationEventData = any;
-
   interface ViewProps extends EventHandlerProps {
     name?: string;
     parentedBoneName?: string;
@@ -1367,6 +1311,369 @@ declare module "magic-script-components" {
   }
 
   const Line: React.FC<LineProps>;
+
+  interface EventHandlerProps {
+    onActivate?: (eventData: UiEventData) => void;
+    onClick?: (eventData: UiEventData) => void;
+    onPress?: (eventData: UiEventData) => void;
+    onLongPress?: (eventData: UiEventData) => void;
+    onRelease?: (eventData: UiEventData) => void;
+    onHoverEnter?: (eventData: UiEventData) => void;
+    onHoverExit?: (eventData: UiEventData) => void;
+    onHoverMove?: (eventData: UiEventData) => void;
+    onEnabled?: (eventData: UiEventData) => void;
+    onDisabled?: (eventData: UiEventData) => void;
+    onFocusGained?: (eventData: UiEventData) => void;
+    onFocusLost?: (eventData: UiEventData) => void;
+    onFocusInput?: (eventData: UiEventData) => void;
+    onUpdate?: (eventData: UiEventData) => void;
+    onDelete?: (eventData: UiEventData) => void;
+    onCharacterEnter?: (eventData: TextEditEventData) => void;
+    onKeyboardEvent?: (eventData: TextEditEventData) => void;
+    onTextChanged?: (eventData: TextEditEventData) => void;
+    onSliderChanged?: (eventData: SliderEventData) => void;
+    onScrollChanged?: (eventData: ScrollViewEventData) => void;
+    onProgressBarChanged?: (eventData: ProgressBarEventData) => void;
+    onListVisibilityChanged?: (eventData: DropDownListEventData) => void;
+    onSelectionChanged?: (eventData: DropDownListEventData) => void;
+    onToggleChanged?: (eventData: ToggleEventData) => void;
+    onCursorEdge?: (eventData: UiEventData) => void;
+    onCursorOffEdge?: (eventData: UiEventData) => void;
+    onPanelEnter?: (eventData: UiEventData) => void;
+    onPanelExit?: (eventData: UiEventData) => void;
+    onDialogCanceled?: (eventData: UiEventData) => void;
+    onDialogConfirmed?: (eventData: UiEventData) => void;
+    onDialogTimeExpired?: (eventData: UiEventData) => void;
+    onColorCanceled?: (eventData: ColorPickerEventData) => void;
+    onColorChanged?: (eventData: ColorPickerEventData) => void;
+    onColorConfirmed?: (eventData: ColorPickerEventData) => void;
+    onTimeChanged?: (eventData: TimePickerEventData) => void;
+    onTimeConfirmed?: (eventData: TimePickerEventData) => void;
+    onDateChanged?: (eventData: DatePickerEventData) => void;
+    onDateConfirmed?: (eventData: DatePickerEventData) => void;
+    onConfirmationCanceled?: (eventData: CircleConfirmationEventData) => void;
+    onConfirmationCompleted?: (eventData: CircleConfirmationEventData) => void;
+    onConfirmationUpdated?: (eventData: CircleConfirmationEventData) => void;
+  }
+
+  // Event Data:
+  // --------------------------------------------------------------------------------
+
+  interface UiEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+  }
+
+  interface TextEditEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Text?: any;
+  }
+
+  interface SliderEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Max?: any;
+    Min?: any;
+    Value?: any;
+  }
+
+  interface ScrollViewEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    ScrollValue?: any;
+  }
+
+  interface ProgressBarEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Max?: any;
+    Min?: any;
+    Value?: any;
+    ProgressColor?: any;
+  }
+
+  interface DropDownListEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+  }
+
+  interface ToggleEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    On?: any;
+    Text?: any;
+    TextColor?: any;
+    TextSize?: any;
+  }
+
+  interface ColorPickerEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Color?: any;
+  }
+
+  interface TimePickerEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Time?: any;
+    TimeString?: any;
+  }
+
+  interface DatePickerEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Date?: any;
+    DateString?: any;
+  }
+
+  interface CircleConfirmationEventData {
+    AABB?: any;
+    AnchorPosition?: any;
+    ChildCount?: any;
+    CurrentPrismTransform?: any;
+    CurrentWorldTransform?: any;
+    CursorHoverState?: any;
+    LocalAABB?: any;
+    LocalTransform?: any;
+    Name?: any;
+    NodeId?: any;
+    ParentedBoneName?: any;
+    PrismId?: any;
+    LocalPosition?: any;
+    LocalRotation?: any;
+    LocalScale?: any;
+    PrismPosition?: any;
+    WorldPosition?: any;
+    Alignment?: any;
+    Enabled?: any;
+    EventPassThrough?: any;
+    EventSoundID?: any;
+    GravityWellEnabled?: any;
+    GravityWellProperties?: any;
+    RenderingLayer?: any;
+    Angle?: any;
+  }
 
   // Other Types:
   // --------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-script-components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MagicScript Component Framework",
   "module": "index.js",
   "files": [


### PR DESCRIPTION
This also includes a change to make the prop types hierarchical (making it easy to pick out relevant props for specific component types, vs. those common to all components or large groups like UI components).