### PR TITLE
Update Line node group in  CommonEvents document

### DIFF
--- a/docs/events/CommonEvents.md
+++ b/docs/events/CommonEvents.md
@@ -32,7 +32,6 @@ supported by all of the following components:
 - DropdownList
 - GridLayout
 - Image
-- Line
 - LinearLayout
 - ListView
 - ListViewItem
@@ -59,6 +58,7 @@ supported by all of the following components:
 - Audio
 - Content
 - Light
+- Line
 - Model
 - Quad
 - Video


### PR DESCRIPTION
Line element does not extend UiNode so needs to be moved to the group of elements supporting onEvent and onUpdateLoop events only.
